### PR TITLE
Simplify the maven pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,20 +14,14 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <failOnMissingWebXml>false</failOnMissingWebXml>
-        <!-- Plugin versions -->
-        <version.liberty-plugin>3.0.1</version.liberty-plugin>
-        <version.maven-war-plugin>3.2.2</version.maven-war-plugin>
-        <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
-        <version.maven-failsafe-plugin>2.22.2</version.maven-failsafe-plugin>
     </properties>
 
     <dependencies>
         <!-- Provided dependencies -->
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-web-api</artifactId>
-            <version>8.0.1</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -79,32 +73,24 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>${version.liberty-plugin}</version>
-                <configuration>
-                    <assemblyArtifact>
-                        <groupId>io.openliberty</groupId>
-                        <artifactId>openliberty-kernel</artifactId>
-                        <version>[19.0.0.4,)</version>
-                        <type>zip</type>
-                    </assemblyArtifact>
-               </configuration>
+                <version>3.0.1</version>
             </plugin>
             <!-- end::libertyMavenPlugin[] -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${version.maven-war-plugin}</version>
+                <version>3.2.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${version.maven-surefire-plugin}</version>
+                <version>2.22.2</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${version.maven-failsafe-plugin}</version>
+                <version>2.22.2</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
In order to simplify the maven pom and to use the latest API dependencies I've made the following changes:

1. Removed the Liberty version configuration is redundant since it is just the built in configuration
2. Inlined the maven plugin versions which are (I think) the common practice and that removes 3 properties.
3. Removed the fail on missing web.xml which isn't required because we have Servlet 4 on the classpath.
4. Update to use the Jakarta EE 8 api dependency.