### PR TITLE
Add jaxb-api for JDK 9 and above

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     testCompile 'org.apache.cxf:cxf-rt-rs-client:3.2.6'
     testCompile 'org.apache.cxf:cxf-rt-rs-extension-providers:3.2.6'
     testCompile 'org.glassfish:javax.json:1.0.4'
+    testCompile 'javax.xml.bind:jaxb-api:2.3.1'
 }
 
 clean.dependsOn 'libertyStop'


### PR DESCRIPTION
When using JDK 9 and above, tests fail with JAXBException unless we add the jaxb-api to the test classpath as per https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j