### PR TITLE
Use LGP 3.0-M1, update cxf versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,13 +11,9 @@ tasks.withType(JavaCompile) {
 buildscript {
     repositories {
         mavenCentral()
-        maven {
-            name = 'Sonatype Nexus Snapshots'
-            url = 'https://oss.sonatype.org/content/repositories/snapshots/'
-        }
     }
     dependencies {
-        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.0-M1-SNAPSHOT'
+        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.0-M1'
     }
 }
 
@@ -32,8 +28,8 @@ dependencies {
 
     // test dependencies
     testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.2.6'
-    testCompile 'org.apache.cxf:cxf-rt-rs-extension-providers:3.2.6'
+    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.3.4'
+    testCompile 'org.apache.cxf:cxf-rt-rs-extension-providers:3.3.4'
     testCompile 'org.glassfish:javax.json:1.0.4'
     testCompile 'javax.xml.bind:jaxb-api:2.3.1'
 }


### PR DESCRIPTION
- Use liberty-gradle-plugin 3.0-M1
- Update cxf versions to avoid the following warning found in 3.2.6:
```
WARNING: Illegal reflective access by org.apache.cxf.common.util.ReflectionUtil$11 (file:/Users/eric/.gradle/caches/modules-2/files-2.1/org.apache.cxf/cxf-core/3.2.6/de6b2ef9cb8a45ec5417f6783d6640851a2c9547/cxf-core-3.2.6.jar) to field java.net.Authenticator.theAuthenticator
```