### PR TITLE
Gradle use testImplementation instead of testCompile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,11 @@ dependencies {
     providedCompile 'org.eclipse.microprofile:microprofile:3.0'
 
     // test dependencies
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.3.4'
-    testCompile 'org.apache.cxf:cxf-rt-rs-extension-providers:3.3.4'
-    testCompile 'org.glassfish:javax.json:1.0.4'
-    testCompile 'javax.xml.bind:jaxb-api:2.3.1'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.cxf:cxf-rt-rs-client:3.3.4'
+    testImplementation 'org.apache.cxf:cxf-rt-rs-extension-providers:3.3.4'
+    testImplementation 'org.glassfish:javax.json:1.0.4'
+    testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
 }
 
 clean.dependsOn 'libertyStop'


### PR DESCRIPTION
Fixes #16 gradle deprecation warning when using the demo-devmode project with gradle 6.0.1
```
gradle clean libertyDev --warning-mode all

> Configure project :
The testCompile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the testImplementation configuration instead.
```